### PR TITLE
Reorganized README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,34 +3,12 @@
 > Learn elm faster and in a fun way
 
 ![Elm rope implemented using frolic](images/elm-rope-in-elm-playground.png)
-![Elm counter pairs from elm-architechture examples](images/elm-playground-desktop-counter-pairs.gif)
 
-### How to try it out
-```
-npm install
-npm install elm -g -- in case you don't have elm installed already
-npm run build
-npm run start
-```
-
-**Notes**
-1. Still in heavy development mode. Contributions and feedback are welcome.
-2. To test out your ui components just copy whatever you would pass to `main` and call it (in the playground panel) will a function named `render` (also checkout the gif in case of confusion). E.g.
-```
-render
-    { init = init
-    , view = view
-    , update = update
-    , subscriptions = subscriptions
-    }
-```
-
-### Why frolic
-The project was inspired by [haskell for mac](http://haskellformac.com). The main idea is to have a playground panel where users can type out code expressions and see the result instantaneously without any setup. There is a similar thing currently for elm ([elm-lang.org/try](elm-lang.org/try)) but it has limited functionality and doesn't work without having the ui layer (model, view, update, main etc.).
+Inspired by [haskell for mac](http://haskellformac.com), the idea is to have a playground panel where users can type out code expressions and see the result instantaneously without any setup. There is a similar thing currently for elm ([elm-lang.org/try](elm-lang.org/try)) but it has limited functionality and doesn't work without having the ui layer (model, view, update, main etc.).
 
 In frolic, you can start typing your expressions and see result in the output panel without any glue code. Plus, it works for ui components too.
 
-### Feature list
+## Features
 
 - Immediate feedback
 - Quick way for someone new to the language to try it out
@@ -39,6 +17,32 @@ In frolic, you can start typing your expressions and see result in the output pa
 - Can load files from the disk and the dependencies will be resolves automatically
 - Can save playground code as a file. Also, when the code file is loaded in the future, the playground file automatically gets loaded with it. That way, you can think of the playground code as sort of clojurescript devcards.
 - Having multiple ui components to try out in same output window (like [clojurescript devcards](https://github.com/bhauman/devcards))
+
+#### The project is still in heavy development. You currently need to clone and run locally. Contributions and feedback are welcome!
+
+# Setup
+
+```
+git clone https://github.com/mukeshsoni/frolic
+npm install
+npm install elm -g -- in case you don't have elm installed already
+npm run build
+npm run start
+```
+
+![Elm counter pairs from elm-architechture examples](images/elm-playground-desktop-counter-pairs.gif)
+
+
+**Notes**
+To test out your ui components just copy whatever you would pass to `main` and call it (in the playground panel) will a function named `render` (also checkout the gif in case of confusion). E.g.
+```
+render
+    { init = init
+    , view = view
+    , update = update
+    , subscriptions = subscriptions
+    }
+```
 
 ### How to setup the dev environment
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,6 @@
 # Frolic
 
-> Learn elm faster and in a fun way
-
-![Elm rope implemented using frolic](images/elm-rope-in-elm-playground.png)
-
-Inspired by [haskell for mac](http://haskellformac.com), the idea is to have a playground panel where users can type out code expressions and see the result instantaneously without any setup. There is a similar thing currently for elm ([elm-lang.org/try](elm-lang.org/try)) but it has limited functionality and doesn't work without having the ui layer (model, view, update, main etc.).
-
-In frolic, you can start typing your expressions and see result in the output panel without any glue code. Plus, it works for ui components too.
+With Frolic, you can start typing expressions and immediately see results in the output panel without any glue code. Plus, it works for ui components too!
 
 ## Features
 
@@ -18,22 +12,23 @@ In frolic, you can start typing your expressions and see result in the output pa
 - Can save playground code as a file. Also, when the code file is loaded in the future, the playground file automatically gets loaded with it. That way, you can think of the playground code as sort of clojurescript devcards.
 - Having multiple ui components to try out in same output window (like [clojurescript devcards](https://github.com/bhauman/devcards))
 
+![Elm counter pairs from elm-architechture examples](images/elm-playground-desktop-counter-pairs.gif)
+
+Frolic was inspired by [haskell for mac](http://haskellformac.com), the idea is to have a playground panel where users can type out code expressions and see the result instantaneously without any setup. There is a similar thing currently for elm ([elm-lang.org/try](elm-lang.org/try)) but it has limited functionality and doesn't work without having the ui layer (model, view, update, main etc.).
+
 #### The project is still in heavy development. You currently need to clone and run locally. Contributions and feedback are welcome!
 
-# Setup
+## Setup
 
 ```
+npm install elm -g -- in case you don't have elm installed already
 git clone https://github.com/mukeshsoni/frolic
 npm install
-npm install elm -g -- in case you don't have elm installed already
 npm run build
 npm run start
 ```
 
-![Elm counter pairs from elm-architechture examples](images/elm-playground-desktop-counter-pairs.gif)
-
-
-**Notes**
+**Note**
 To test out your ui components just copy whatever you would pass to `main` and call it (in the playground panel) will a function named `render` (also checkout the gif in case of confusion). E.g.
 ```
 render
@@ -44,38 +39,7 @@ render
     }
 ```
 
-### How to setup the dev environment
-
-```
-npm install
-npm install elm -g -- in case you don't have elm installed already
--- go to folder app/compilers/elm/temp/ and do
-elm-package install -y
--- from the root folder run
-npm run hot-server
-npm run start-hot
-```
-
-### List of packages includes in the app by default -
-- elm-community/array-extra
-- elm-community/basics-extra
-- elm-community/dict-extra
-- elm-community/easing-functions
-- elm-community/elm-lazy-list
-- elm-community/elm-linear-algebra
-- elm-community/elm-material-icons
-- elm-community/elm-webgl
-- elm-community/graph
-- elm-community/html-extra
-- elm-community/intdict
-- elm-community/json-extra
-- elm-community/list-split
-- elm-community/maybe-extra
-- elm-community/random-extra
-- elm-community/result-extra
-- elm-community/string-extra
-- elm-community/svg-extra
-- elm-community/undo-redo
+## Packages included by default
 - elm-lang/animation-frame
 - elm-lang/core
 - elm-lang/dom
@@ -92,6 +56,37 @@ npm run start-hot
 - elm-lang/window
 - evancz/elm-http
 - evancz/elm-markdown
+- elm-community/undo-redo
+- elm-community/easing-functions
+- elm-community/elm-lazy-list
+- elm-community/elm-linear-algebra
+- elm-community/elm-material-icons
+- elm-community/elm-webgl
+- elm-community/graph
+- elm-community/intdict
+- elm-community/list-split
+- elm-community/html-extra
+- elm-community/json-extra
+- elm-community/maybe-extra
+- elm-community/random-extra
+- elm-community/result-extra
+- elm-community/string-extra
+- elm-community/svg-extra
+- elm-community/array-extra
+- elm-community/basics-extra
+- elm-community/dict-extra
+
+## Dev setup
+
+```
+npm install
+npm install elm -g -- in case you don't have elm installed already
+-- go to folder app/compilers/elm/temp/ and do
+elm-package install -y
+-- from the root folder run
+npm run hot-server
+npm run start-hot
+```
 
 ## Maintainers
 


### PR DESCRIPTION
I'd like to add a little stronger call to action at the end of the setup steps, Does `npm run start` print out of url to open in the browser? It'd be nice to explicitly say in the readme "Then open up http://localhost:8000"

I guess I'll find out in a minute.. :)

Feel free to further edit my edits Mukesh :)
