### PR TITLE
Fix use of elm-format so that files containing quotes can be saved

### DIFF
--- a/app/compilers/elm/elm.js
+++ b/app/compilers/elm/elm.js
@@ -377,7 +377,16 @@ function generateTests(code, playgroundCode, openFilePath) {
 }
 
 function formatCode(code) {
-    return promisifiedExec(`echo "${code}" | ${basePath}/elm-format --stdin`)
+    const cmd = `${basePath}/elm-format --stdin`
+
+    function execFormat(callback) {
+        const child = exec(cmd, callback)
+        child.stdin.write(code)
+        child.stdin.end()
+        return child
+    }
+
+    return Promise.promisify(execFormat)()
             // .then((formattedCode) => _.drop(formattedCode.split('\n'), 2).join('\n'))
 }
 


### PR DESCRIPTION
This is a fix for https://github.com/mukeshsoni/frolic/issues/3

Without this fix, files containing double quotes cannot be saved if format-on-save is enabled.

Sorry, my javascript is a bit rusty.. Creating a new nested function here might not be the best way to implement this.
